### PR TITLE
Fix issue when starting the webserver

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -17,7 +17,7 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   experimental: {
-    serverComponentsExternalPackages: ["@sentry/nextjs", "@sentry/node"],
+    serverComponentsExternalPackages: ["@sentry/nextjs", "@sentry/node", "jiti"],
     instrumentationHook: true,
     turbo: {
       rules: {


### PR DESCRIPTION
Fixes #1

Add `jiti` to the `serverComponentsExternalPackages` array in the `experimental` section of `apps/web/next.config.mjs`.

* Modify the `serverComponentsExternalPackages` array to include `jiti` along with `@sentry/nextjs` and `@sentry/node`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bchoor/inbox-zero/pull/2?shareId=217b2239-003a-4a95-bd79-918d3b904315).